### PR TITLE
:sparkles: feat: 펫 공고 등록 상태 관리 기능 추가

### DIFF
--- a/src/main/java/hello/pet/petservice/controller/PetController.java
+++ b/src/main/java/hello/pet/petservice/controller/PetController.java
@@ -56,4 +56,10 @@ public class PetController {
         petService.deletePet(petId, userId, userRole);
         return ResponseEntity.noContent().build();
     }
+
+    @PatchMapping("/{petId}/mark-announced")
+    public ResponseEntity<Void> markAsAnnounced(@PathVariable Long petId) {
+        petService.markAsAnnounced(petId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/hello/pet/petservice/entity/Pet.java
+++ b/src/main/java/hello/pet/petservice/entity/Pet.java
@@ -53,6 +53,17 @@ public class Pet {
     @Column(length = 500)
     private String imageUrl;
 
+    @Column(nullable = false)
+    private Boolean announced = false; // 공고 등록 여부 (기본 false)
+
+    public void markAsAnnounced() {
+        this.announced = true;
+    }
+
+    public void unmarkAsAnnounced() {
+        this.announced = false;
+    }
+
     public void updateInfo(PetPatchRequest request) {
         if (request.getAnimalType() != null) {
             this.animalType = request.getAnimalType();

--- a/src/main/java/hello/pet/petservice/service/PetService.java
+++ b/src/main/java/hello/pet/petservice/service/PetService.java
@@ -62,6 +62,16 @@ public class PetService {
         petRepository.delete(pet);
     }
 
+    public void markAsAnnounced(Long petId) {
+        Pet pet = findById(petId);
+
+        if (Boolean.TRUE.equals(pet.getAnnounced())) {
+            throw new IllegalStateException("이미 공고가 등록된 펫입니다.");
+        }
+
+        pet.markAsAnnounced();
+    }
+
     private Pet findById(Long petId) {
         return petRepository.findById(petId)
                             .orElseThrow(() -> new EntityNotFoundException("Pet을 찾을 수 없습니다. id=" + petId));


### PR DESCRIPTION
## 📌 작업 내용
<!-- 이번 PR에서 수정/추가된 핵심 내용을 간단히 작성하세요 -->
입양 공고 등록 시 펫 상태를 표시하기 위해 Pet 엔티티와 API를 확장함

## 🔗 관련 이슈
Closes #7 

## ✅ PR 생성 전 체크리스트
- [x] 병합할 브랜치 확인
- [ ] 코드 정상 동작 확인

## 💬 리뷰 메모
<!-- 리뷰어에게 강조하거나 논의할 부분을 작성하세요-->
