### PR TITLE
:sparkles: feat: 보호소 별 펫 목록 조회 기능 추가

### DIFF
--- a/src/main/java/hello/pet/petservice/controller/PetController.java
+++ b/src/main/java/hello/pet/petservice/controller/PetController.java
@@ -5,6 +5,7 @@ import hello.pet.petservice.dto.request.PetPatchRequest;
 import hello.pet.petservice.dto.response.PetResponse;
 import hello.pet.petservice.service.PetService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,6 +39,13 @@ public class PetController {
     @GetMapping("/{petId}")
     public ResponseEntity<PetResponse> getPet(@PathVariable Long petId) {
         PetResponse response = petService.getPet(petId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PetResponse>> getPets(@RequestParam Long shelterId,
+                                                     @RequestParam(required = false) Boolean announced) {
+        List<PetResponse> response = petService.getPetsByShelter(shelterId, announced);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/hello/pet/petservice/repository/PetRepository.java
+++ b/src/main/java/hello/pet/petservice/repository/PetRepository.java
@@ -1,9 +1,13 @@
 package hello.pet.petservice.repository;
 
 import hello.pet.petservice.entity.Pet;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PetRepository extends JpaRepository<Pet, Long> {
+    List<Pet> findAllByShelterId(Long shelterId);
+
+    List<Pet> findAllByShelterIdAndAnnounced(Long shelterId, Boolean announced);
 }

--- a/src/main/java/hello/pet/petservice/service/PetService.java
+++ b/src/main/java/hello/pet/petservice/service/PetService.java
@@ -7,6 +7,8 @@ import hello.pet.petservice.entity.Pet;
 import hello.pet.petservice.exception.ForbiddenException;
 import hello.pet.petservice.repository.PetRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +33,21 @@ public class PetService {
     public PetResponse getPet(Long petId) {
         Pet pet = findById(petId);
         return PetResponse.from(pet);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PetResponse> getPetsByShelter(Long shelterId, Boolean announced) {
+        List<Pet> pets;
+
+        if (announced == null) {
+            pets = petRepository.findAllByShelterId(shelterId);
+        } else {
+            pets = petRepository.findAllByShelterIdAndAnnounced(shelterId, announced);
+        }
+
+        return pets.stream()
+                   .map(PetResponse::from)
+                   .collect(Collectors.toList());
     }
 
     public PetResponse updatePet(Long petId, PetPatchRequest request, Long userId, String userRole) {


### PR DESCRIPTION
## 📌 작업 내용
<!-- 이번 PR에서 수정/추가된 핵심 내용을 간단히 작성하세요 -->
보호소 별로 본인이 등록한 펫들을 조회할 수 있는 기능을 구현했습니다.

## 🔗 관련 이슈
Closes #9 

## ✅ PR 생성 전 체크리스트
- [x] 병합할 브랜치 확인
- [ ] 코드 정상 동작 확인

## 💬 리뷰 메모
<!-- 리뷰어에게 강조하거나 논의할 부분을 작성하세요-->
