### PR TITLE
:recycle: refactor: 보호소 인증 방식을 RequestHeader 기반으로 변경

### DIFF
--- a/src/main/java/hello/pet/petservice/controller/PetController.java
+++ b/src/main/java/hello/pet/petservice/controller/PetController.java
@@ -43,8 +43,9 @@ public class PetController {
     }
 
     @GetMapping
-    public ResponseEntity<List<PetResponse>> getPets(@RequestParam Long shelterId,
-                                                     @RequestParam(required = false) Boolean announced) {
+    public ResponseEntity<List<PetResponse>> getPets(@RequestHeader("X-User-Id") Long shelterId,
+                                                     @RequestParam(required = false) Boolean announced
+    ) {
         List<PetResponse> response = petService.getPetsByShelter(shelterId, announced);
         return ResponseEntity.ok(response);
     }


### PR DESCRIPTION
## 📌 작업 내용
<!-- 이번 PR에서 수정/추가된 핵심 내용을 간단히 작성하세요 -->
pet-service의 보호소 별 펫 목록 조회 API에서 @RequestParam shelterId → @RequestHeader("X-User-Id")로 수정했습니다.

## 🔗 관련 이슈
Closes #11 

## ✅ PR 생성 전 체크리스트
- [x] 병합할 브랜치 확인
- [ ] 코드 정상 동작 확인

## 💬 리뷰 메모
<!-- 리뷰어에게 강조하거나 논의할 부분을 작성하세요-->
