### PR TITLE
:sparkles: feat: Pet 공고 해제 API 추가

### DIFF
--- a/src/main/java/hello/pet/petservice/controller/PetController.java
+++ b/src/main/java/hello/pet/petservice/controller/PetController.java
@@ -72,4 +72,10 @@ public class PetController {
         petService.markAsAnnounced(petId);
         return ResponseEntity.noContent().build();
     }
+
+    @PatchMapping("/{petId}/unmark-announced")
+    public ResponseEntity<Void> markAsUnannounced(@PathVariable Long petId) {
+        petService.markAsUnannounced(petId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/hello/pet/petservice/service/PetService.java
+++ b/src/main/java/hello/pet/petservice/service/PetService.java
@@ -90,6 +90,16 @@ public class PetService {
         pet.markAsAnnounced();
     }
 
+    public void markAsUnannounced(Long petId) {
+        Pet pet = findById(petId);
+
+        if (Boolean.FALSE.equals(pet.getAnnounced())) {
+            throw new IllegalStateException("이미 공고가 해제된 펫입니다.");
+        }
+
+        pet.unmarkAsAnnounced();
+    }
+
     private Pet findById(Long petId) {
         return petRepository.findById(petId)
                             .orElseThrow(() -> new EntityNotFoundException("Pet을 찾을 수 없습니다. id=" + petId));


### PR DESCRIPTION
## 📌 작업 내용
<!-- 이번 PR에서 수정/추가된 핵심 내용을 간단히 작성하세요 -->
펫의 공고 등록 상태를 false로 변경시키는 API 추가했습니다.

## 🔗 관련 이슈
Closes #15 

## ✅ PR 생성 전 체크리스트
- [x] 병합할 브랜치 확인
- [x] 코드 정상 동작 확인

## 💬 리뷰 메모
<!-- 리뷰어에게 강조하거나 논의할 부분을 작성하세요-->
