### PR TITLE
🐛 fix: ImageServiceClient에 FeignConfig 설정 추가

### DIFF
--- a/src/main/java/hello/pet/petservice/client/ImageServiceClient.java
+++ b/src/main/java/hello/pet/petservice/client/ImageServiceClient.java
@@ -9,7 +9,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 @FeignClient(
         name = "image-service",
-        url = "${IMAGE_SERVICE_URL:http://localhost:8088}"
+        url = "${IMAGE_SERVICE_URL:http://localhost:8088}",
+        configuration = hello.pet.petservice.config.FeignConfig.class
 )
 public interface ImageServiceClient {
 


### PR DESCRIPTION
- Board Service와 동일하게 configuration 파라미터 추가
- SpringFormEncoder가 multipart/form-data 요청을 제대로 처리하도록 설정
- 이미지 업로드 시 S3 키가 저장되지 않는 문제 해결

문제 원인:
- FeignConfig가 있었지만 ImageServiceClient에서 사용하지 않음
- @RequestPart로 전달되는 파라미터들이 제대로 인코딩되지 않음

## 📌 작업 내용
<!-- 이번 PR에서 수정/추가된 핵심 내용을 간단히 작성하세요 -->

## 🔗 관련 이슈
Closes #

## ✅ PR 생성 전 체크리스트
- [ ] 병합할 브랜치 확인
- [ ] 코드 정상 동작 확인

## 💬 리뷰 메모
<!-- 리뷰어에게 강조하거나 논의할 부분을 작성하세요-->
